### PR TITLE
Do partial header-matching

### DIFF
--- a/headerexp/header_matcher.go
+++ b/headerexp/header_matcher.go
@@ -27,13 +27,15 @@ func (q *HeaderExpr) MatchString(headerStrings ...string) bool {
 }
 
 // MatchHeader will match the http.Header structure against the HeaderExpr,
-// and return true if all parameters are matched, if not false is returned
+// and return true all headers present in the request matches a HeaderExpr if one is
+// found for the specific header. If no HeaderExpr is found for a passed header it
+// is ignored thus will *not* fail the match.
 func (q *HeaderExpr) MatchHeader(h http.Header) bool {
 	m := make(map[string]string)
 	for k, v := range h {
 		m[k] = v[0]
 	}
-	return q.MatchMap(m)
+	return q.MatchIfPresentMap(m)
 }
 
 // Compile, will create a HeaderExpr from a string in URL query format, but with

--- a/keyvalueexp/key_value_expression.go
+++ b/keyvalueexp/key_value_expression.go
@@ -38,6 +38,22 @@ func (ke *KeyValueExpr) MatchMap(m map[string]string) bool {
 	return true
 }
 
+func (ke *KeyValueExpr) MatchIfPresentMap(m map[string]string) bool {
+	if len(m) == 0 && len(ke.paramMatchers) != 0 {
+		return false // no params but we have matchers
+	}
+	for k, matcher := range ke.paramMatchers {
+		v, ok := m[k]
+		if !ok {
+			continue
+		}
+		if !matcher.MatchString(v) {
+			return false // value does not match
+		}
+	}
+	return true
+}
+
 // MustCompile, this performs the same function as Compile, but it will panic if
 // unable to successfully Compile.
 func MustCompile(keyValue map[string]string) *KeyValueExpr {


### PR DESCRIPTION
Changed the behaviour of header-matching, to only check the headers for which rules have been defind, and *not* require rules for all headers passed. This is more useful.