### PR TITLE
Adding value substitution #8 (hostname/base_url)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,20 @@ the match-group, and `p` denotes that it is groups from the `path-matcher`, `b` 
 
 The match-groups are also available in `after-script` where they can be accessed as env-vars named in the same manor
 as described above, ex `echo $p1 >> the_file.log`
+
+# Environment variables in conversations
+Any environment variable prefixed with `MOCKDEV_` will be available in conversations, when generating response body.
+ex. `MOCDEV_FOO` will be available using `{{ .ENV.FOO }}`. The current bind address, and the bind port is available as:
+`{{ .CFG.Address }}` and `{{ .CFG.Port }}` (_note that the `Address` will most likely be `""` meaning that mockdev is
+bound to all addresses_)
+
+# Breaking conversations
+It is now possible to make the match, or the failure to match a conversation break the "conversation matching" and
+respond with the conversation breaking the matching. This is done by setting the `break-on` property on a conversation.
+
+Possible values are
+  - `no-match` This will break the conversation-matching if the specific conversation is not matched. Please note that
+    conversation will only break if _configured_ matchers fail.
+  - `match` Will break the matching if the conversation matches.
+
+An example of usage can be found in [config.yaml](_examples/configuration/config.yaml) in the "fake-auth" conversation.

--- a/_examples/configuration/config.yaml
+++ b/_examples/configuration/config.yaml
@@ -35,7 +35,7 @@ http:
           status-code: 200
           headers:
             - "Content-Type: text/plain"
-          body: Hello World, from mocdevd
+          body: Hello World, from mocdevd ( {{.ENV.BASE_URL}} )
         # all lines in script will be executed as follows: 'sh -c $line'
         # if any line returns "non zero" the script breaks.
         after-script:
@@ -54,20 +54,24 @@ http:
           headers:
             - "Content-Type: text/plain"
           body: Hello World, cool, from mocdevd
-      - name: "fake auth"
-        # "match" or "no-match", "" or absent => no breaking
-        break-on: no-match
-        match-order: -1
-        request:
-          # "contains" or "if-present", "" or absent => "if-present"
-          header-match-type: "contains"
-          header-matchers:
-            - "Foo: .*"
-        response:
-          status-code: 401
-          headers:
-            - "Content-Type: text/plain"
-          body: "401 I don't know you... yet."
+#
+# Below is an example of how "header auth could be constructed
+# please note that using 'break-on: no-match' can be a bit tricky if other non-greaking
+# conversations are also configured
+#      - name: "fake auth"
+#        # "match" or "no-match", "" or absent => no breaking
+#        break-on: no-match
+#        match-order: -1
+#        request:
+#          # "contains" or "if-present", "" or absent => "if-present"
+#          header-match-type: "contains"
+#          header-matchers:
+#            - "Foo: .*"
+#        response:
+#          status-code: 401
+#          headers:
+#            - "Content-Type: text/plain"
+#          body: "401 I don't know you... yet."
 
 ssh:
   - name: default

--- a/_examples/configuration/config.yaml
+++ b/_examples/configuration/config.yaml
@@ -35,7 +35,7 @@ http:
           status-code: 200
           headers:
             - "Content-Type: text/plain"
-          body: Hello World, from mocdevd ( {{.ENV.BASE_URL}} )
+          body: Hello World, from mocdevd ( {{.env.BASE_URL}} )
         # all lines in script will be executed as follows: 'sh -c $line'
         # if any line returns "non zero" the script breaks.
         after-script:

--- a/cmd/mockdevd/mockdevd.go
+++ b/cmd/mockdevd/mockdevd.go
@@ -101,6 +101,7 @@ func startHttpService(config *mockhttp.Configuration, logger *logrus.Entry) {
 		Log:                logger,
 		SessionLogReceived: config.Logging.LogReceived,
 		SessionLogLocation: config.Logging.Location,
+		BindAddress:        config.BindAddr,
 	})
 	if err != nil {
 		logger.Error(err)

--- a/mockhttp/template_data.go
+++ b/mockhttp/template_data.go
@@ -1,0 +1,36 @@
+package mockhttp
+
+import (
+	"os"
+	"strings"
+)
+
+const cfg = "CFG"
+const env = "ENV"
+const envPrefix = "MOCKDEV_"
+
+type templateData map[string]interface{}
+type envData map[string]string
+
+type templateConfigData struct {
+	Address string
+	Port    string
+}
+
+func createConfigData(addressPort string) templateConfigData {
+	segs := strings.SplitN(addressPort, ":", 2)
+	return templateConfigData{
+		segs[0], segs[1],
+	}
+}
+
+func createEnvData() envData {
+	evd := make(envData)
+	for _, tuple := range os.Environ() {
+		segs := strings.SplitN(tuple, "=", 2)
+		if strings.HasPrefix(segs[0], envPrefix) {
+			evd[strings.TrimPrefix(segs[0], envPrefix)] = segs[1]
+		}
+	}
+	return evd
+}

--- a/mockhttp/template_data.go
+++ b/mockhttp/template_data.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 )
 
-const cfg = "CFG"
-const env = "ENV"
+const cfg = "cfg"
+const env = "env"
 const envPrefix = "MOCKDEV_"
 
 type templateData map[string]interface{}


### PR DESCRIPTION
It is now possible to add variables to the mockdev daemon execution environment, that will be available for value substitution when generation response bodies.